### PR TITLE
Docs fixes and better class discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2025-03-07
+- Fixed config instructions in README and hex docs
+
 ## [0.1.1] - 2025-03-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ end
 Configure the SDK in your `config.exs` (or environment-specific config file) using environment variables:
 
 ```elixir
-config :bento_sdk,
+config :bento_sdk, BentoSdk, 
   site_uuid: System.get_env("BENTO_SITE_UUID", "your_site_uuid"),
   username: System.get_env("BENTO_USERNAME", "your_username"),
   password: System.get_env("BENTO_PASSWORD", "your_password")

--- a/lib/bento_sdk.ex
+++ b/lib/bento_sdk.ex
@@ -6,7 +6,7 @@ defmodule BentoSdk do
 
   Add the following to your config.exs (or environment specific config file) to use environment variables:
 
-      config :bento_sdk,
+      config :bento_sdk, BentoSdk,
         site_uuid: System.get_env("BENTO_SITE_UUID", "your_site_uuid"),
         username: System.get_env("BENTO_USERNAME", "your_username"),
         password: System.get_env("BENTO_PASSWORD", "your_password")

--- a/livebook/emails_api.livemd
+++ b/livebook/emails_api.livemd
@@ -57,7 +57,7 @@ Let's send a regular email:
 
 ```elixir
 # Example of sending a regular email
-to_email = "abradburne@gmail.com"
+to_email = "user@example.com"
 from_email = "sender@example.com"
 subject = "Hello from BentoSdk"
 html_body = "<h1>Hello!</h1><p>This is a test email from BentoSdk.</p>"

--- a/livebook/subscribers_api.livemd
+++ b/livebook/subscribers_api.livemd
@@ -36,7 +36,7 @@ Let's find a subscriber by email:
 
 ```elixir
 # Example of finding a subscriber
-email = "example@example.com"
+email = "user@example.com"
 
 case BentoSdk.Subscribers.find(email) do
   {:ok, nil} ->

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BentoSdk.MixProject do
   use Mix.Project
 
-  @version "0.1.1"
+  @version "0.1.2"
   @source_url "https://github.com/abradburne/bento-elixir-sdk"
 
   def project do


### PR DESCRIPTION
fix: examples in docs
fix: added casing for package naming. 